### PR TITLE
Use SMTPHandler

### DIFF
--- a/resource_health_check.py
+++ b/resource_health_check.py
@@ -114,7 +114,6 @@ def main():
     logger.addHandler(log_handler)
 
     for email_address in (args.emails or []):
-        # server_name = socket.getfqdn()
         server_name = socket.gethostname()
         smtp_handler = SMTPHandler(
             mailhost='localhost',


### PR DESCRIPTION
With this the emails arrive at about the same time, it looks like the handler takes care of it with no extra actions on our side:
```
[E 200110 17:03:37 resource_health_check:37] Cannot read the data for ...
[E 200110 17:03:37 resource_health_check:37] Cannot read the data for ...
[E 200110 17:03:37 resource_health_check:37] Cannot read the data for ...
```

Let's keep the `LinuxMailHandler` for now until we are sure the standard `SMTPHandler` works successfully.
Closes #1.